### PR TITLE
Update SupportSingleRecordNavigationLinks.php

### DIFF
--- a/src/Traits/SupportSingleRecordNavigationLinks.php
+++ b/src/Traits/SupportSingleRecordNavigationLinks.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Authorizable;
 
 trait SupportSingleRecordNavigationLinks
 {
+    
     use Authorizable;
     
     public static function singleRecord(): bool


### PR DESCRIPTION
To prevent user editing the wrong model id, added authorization based on request resource id and match it against the singleRecordId() result